### PR TITLE
[1LP][WIPTEST] Implement Openstack create VM.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     oauth2client
     ovirt-engine-sdk-python~=4.3
     openshift==0.3.4
+    openstacksdk>=0.15.0
     packaging
     pyvmomi>=6.5.0.2017.5.post1
     python-cinderclient

--- a/wrapanapi/systems/openstack.py
+++ b/wrapanapi/systems/openstack.py
@@ -623,7 +623,7 @@ class OpenstackSystem(System, VmMixin, TemplateMixin):
         self.username = username
         self.password = password
         self.auth_url = auth_url
-        self.domain_id = kwargs['domain_id'] if self.keystone_version == 3 else None
+        self.domain_id = kwargs.get('domain_id') if self.keystone_version == 3 else None
         self.domain_name = kwargs.get('domain_name') if self.keystone_version == 3 else None
         if self.keystone_version == 3 and self.domain_id is None and self.domain_name is None:
             raise AttributeError("kwargs is missing domain_id or domain_name")

--- a/wrapanapi/systems/openstack.py
+++ b/wrapanapi/systems/openstack.py
@@ -40,6 +40,10 @@ from wrapanapi.exceptions import (
 )
 from wrapanapi.systems.base import System
 
+
+NIC_IP_TYPE_FIXED = "fixed"
+NIC_IP_TYPE_FLOATING = "floating"
+
 # TODO The following monkeypatch nonsense is criminal, and would be
 # greatly simplified if openstack made it easier to specify a custom
 # client class. This is a trivial PR that they're likely to accept.
@@ -155,7 +159,7 @@ class OpenstackInstance(_SharedMethodsMixin, Instance):
         self.refresh()
         return self.raw.addresses
 
-    def get_ip_by_type(self, ip_type):
+    def get_ip_by_type(self, ip_type=NIC_IP_TYPE_FIXED):
         networks = self._get_networks()
         for network_nics in networks.values():
             for nic in network_nics:
@@ -172,15 +176,16 @@ class OpenstackInstance(_SharedMethodsMixin, Instance):
         return [ip for nets in self.raw.networks.values() for ip in nets]
 
     @property
+    def fixed_ip(self):
+        return self.get_ip_by_type(NIC_IP_TYPE_FIXED)
+
+    @property
     def floating_ip(self):
-        return self.get_ip_by_type('floating')
+        return self.get_ip_by_type(NIC_IP_TYPE_FLOATING)
 
     @property
     def ip(self):
-        floating_ip = self.floating_ip
-        if floating_ip:
-            return floating_ip
-        return self.get_ip_by_type('fixed')
+        return self.floating_ip
 
     @property
     def flavor(self):


### PR DESCRIPTION
```python
rom wrapanapi import OpenstackSystem

os_system = OpenstackSystem(
    username=<hidden>,
    password=<hidden>,
    domain_name=<hidden>,
    auth_url=<hidden>,
    tenant=<hidden>,
    app_name="iqe-insights-satellite", app_version="0.1"
)


print("  - test existing open stack instance >>>")
instance = os_system.get_instance("iqe-satellite-test-dlezz-uoaxjidnrg")
print(instance.name)
print(instance.uuid)
print(instance.exists)
print(instance.state)
print(instance.ip)

print(" - test creating a new open stack instance >>>")
new_ins = os_system.create_vm(
    image="rhel-7.6-server-x86_64-released",
    name="iqe-satellite-test-dlezz-124",
    flavor="m1.small",
    key_name=<hidden>,
    network="25ec4907-36fd-7035-b8d5-b797246330f2",
)
# network modified , showing here only the format
assert new_ins.exists
print(new_ins.name)
print(new_ins.uuid)
print(new_ins.exists)
print(new_ins.state)
print(new_ins.ip)
print('delete instance ...')
new_ins.cleanup()
assert not new_ins.exists
```
# test output
```
projects/iqe_insights_satellite/scripts/twrapenapi.py
  - test existing openstack instance >>>
iqe-satellite-test-dlezz-uoaxjidnrg
18ccf865-d41e-4e3f-b740-78463c5525fc
True
VmState.RUNNING
15.2.150.67
 - test creating a new openstack instance >>>
Unmapped VM state 'BUILD' received from system, mapped to 'VmState.UNKNOWN'
iqe-satellite-test-dlezz-124
75fd181d-1482-47f5-bbce-c80293bd21b1
True
VmState.RUNNING
15.2.149.11
delete instance ...
# note the ips was modified in this output .
```
Was able to test it only for api version 3, our upshift service is not configured to allow listing all tenants and has no floating ip configuration.

