### PR TITLE
Set azure meta package version to <5.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ max-line-length = 100
 
 [options]
 install_requires =
-    azure>=3.0.0
+    azure<5.0.0
     azure-storage-common>=1.0
     boto3==1.6.6
     botocore==1.9.6


### PR DESCRIPTION
``` 
RuntimeError:

    

    Starting with v5.0.0, the 'azure' meta-package is deprecated and cannot be installed anymore.

    Please install the service specific packages prefixed by `azure` needed for your application.
```