### PR TITLE
update botocore version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ max-line-length = 100
 install_requires =
     azure<5.0.0
     azure-storage-common>=1.0
-    boto3==1.6.6
-    botocore==1.9.6
+    boto3==1.10.50
+    botocore==1.13.50
     boto
     cached_property
     dateparser


### PR DESCRIPTION
botocore requires update 

update reasoning is explained in [this](https://github.com/SatelliteQE/robottelo/issues/8332) robottelo issue.

My steps:
I found  boto and boto3 is dependant, boto version is not specified in `setup.cfg` but boto3 is so I looked at boto3 versions and found 1.12.0, random release that was after 1.14.0. 
Then I let pip to installed boto3
`pip install boto3 == 1.12.0` and ` botocore >= 1.14.0 ` and pip installed `botocore 1.15.49`