### PR TITLE
Remove suds-jurko requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ install_requires =
     py3winrm==0.0.1
     redfish-client==0.1.0
     requests
-    suds-jurko
     tzlocal
     vspk==5.3.2
     wait_for


### PR DESCRIPTION
We have no direct requirements, and its not installed as a dependency of
any of our existing requirements.

setuptools 58 broke install of suds-jurko because of use_2to3, and the
project is abandoned