### PR TITLE
More generic release version for gha-pypi-publish

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -63,7 +63,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Release to PyPi
-        uses: pypa/gh-action-pypi-publish@release/v1.4.2
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
action failed not finding v1.4.2, even though its available in marketplace. Moving to more generic v1 specifier