### PR TITLE
Update pyvcloud to fix CVE CVE-2017-18342

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "python-neutronclient==6.12.0",
     "python-novaclient==7.1.2",
     "python-swiftclient",
-    "pyvcloud==19.1.2",
+    "pyvcloud==23.0.4",
     "pyvmomi>=6.5.0.2017.5.post1",
     "redfish-client==0.1.0",
     "requests",


### PR DESCRIPTION
Updating the pyvcloud that uses `yaml.safe_load()` to fix the CVE-2017-18342