### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.8, 3.9, 3.12]
+        python: [3.9, 3.12]
     steps:
       - name: Checkout WrapanAPI
         uses: actions/checkout@v3


### PR DESCRIPTION
## Problem statement
In #471, we have hit issues running wrapanapi unit tests with Python 3.8. Errors related to `typing` library were showing up.

## Solution
Unit tests using Python 3.9 do not throw any error, therefore we can drop Python 3.8. 
After talking to @mshriver, we should be good to drop Python 3.8 since all known wrapanapi users are using 3.9+.