### PR TITLE
Add requires-python option to the project config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ keywords = [
     "api",
     "cloud",
 ]
+requires-python = ">=3.9"
 dependencies = [
     "azure-storage-common>=1.0",
     "azure<5.0.0",


### PR DESCRIPTION
## Problem statement
Since we deprecated Python 3.8 in #473, we should set the minimal Python version that wrapanapi requires in its project settings.

## Solution
Add `requires-python` option to pyproject.toml and set it to 3.9+.