### PR TITLE
Pinning the pyOpenSSL as deprecated sign function causing failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ keywords = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "pyopenssl<24.3.0",
     "azure-storage-common>=1.0",
     "azure<5.0.0",
     "boto",


### PR DESCRIPTION
Pinned the pyOpenSSL package as the deprecated sign function in 24.3.0 is causing the failures. Hence pinning the version for now.