### PR TITLE
Pin azure version to install correct version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ requires-python = ">=3.9"
 dependencies = [
     "pyopenssl<24.3.0",
     "azure-storage-common>=1.0",
-    "azure<5.0.0",
+    "azure==4.0.0",
     "boto",
     "boto3",
     "botocore",


### PR DESCRIPTION
Problem Statement:
Robottelo uses uv to install all the dependencies in robottelo and somehow it is installing azure 2.0.0 as it is not able to resolve the dependencies correctly. 
However, when we use pip to install the dependencies, it correctly installs azure 4.0.0. 

Solution:
To avoid the issue, we are pinning azure version to 4.0.0.