### PR TITLE
WrapanAPI pinned again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ keywords = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "pyopenssl<24.3.0",
+    "pyopenssl==24.2.1",
     "azure-storage-common>=1.0",
     "azure==4.0.0",
     "boto",


### PR DESCRIPTION
PyOpenssl version of 22 is being installed when uv package manager is being used for installation when set with less than operator.

Hence pinning to specific version.