### PR TITLE
Add method to fetch virtual devices attached to VM on VMware

### DIFF
--- a/wrapanapi/systems/virtualcenter.py
+++ b/wrapanapi/systems/virtualcenter.py
@@ -697,6 +697,21 @@ class VMWareVMOrTemplate(Entity):
                 result = (None, None)
         return result
 
+    def get_virtual_device_type_names(self):
+        """
+        Retrieves the names of all subclasses of vim.vm.device.VirtualDevice.
+
+        Returns:
+            list: A list of class names (as strings) representing the types of virtual devices.
+        """
+        # Get all subclasses of vim.vm.device.VirtualDevice
+        subclasses = vim.vm.device.VirtualDevice.__subclasses__()
+
+        # Extract only the class names (not fully qualified names) and return
+        class_names = [cls.__name__.split(".")[-1] for cls in subclasses]
+
+        return class_names
+
 
 class VMWareVirtualMachine(VMWareVMOrTemplate, Vm):
     state_map = {


### PR DESCRIPTION
### Results:
```
In [1]: from wrapanapi import VMWareSystem
   ...: from wrapanapi.systems.virtualcenter import VMWareVirtualMachine

In [2]: vmwareclient = VMWareSystem(
   ...:         hostname=vmware.hostname,
   ...:         username=vmware.username,
   ...:         password=vmware.password,
   ...:     )
In [3]: vm = vmwareclient.get_vm('heidi-detten.example.com')
In [4]: vm.get_virtual_device_type_names()
Out[4]:
['VirtualController',
 'VirtualKeyboard',
 'VirtualPointingDevice',
 'VirtualVideoCard',
 'VirtualVMCIDevice',
 'VirtualDisk',
 'VirtualEthernetCard',
 'VirtualTPM']

```