### PR TITLE
Azure VMs listing honours the client resource group now

### DIFF
--- a/wrapanapi/systems/msazure.py
+++ b/wrapanapi/systems/msazure.py
@@ -622,6 +622,7 @@ class AzureSystem(System, VmMixin, TemplateMixin):
         return vm_list
 
     def list_vms(self, resource_group=None):
+        resource_group = resource_group or self.resource_group
         return self.find_vms(resource_group=resource_group)
 
     def get_vm(self, name):


### PR DESCRIPTION
PS:
----
- The Azure listing VMs function is not using resource group attr set in the client object, where other list functions do

Resolution:
-----------
- Using client resource group now to list VMs