### PR TITLE
[TESTS] Add global random seed for deterministic test

### DIFF
--- a/tests/test_hawkular.py
+++ b/tests/test_hawkular.py
@@ -11,7 +11,6 @@ import pytest
 from wrapanapi.systems import HawkularSystem
 from wrapanapi.systems.hawkular import CanonicalPath, Resource, ResourceData, ResourceType
 
-
 seed(17)
 
 

--- a/tests/test_hawkular.py
+++ b/tests/test_hawkular.py
@@ -11,6 +11,8 @@ import pytest
 from wrapanapi.systems import HawkularSystem
 from wrapanapi.systems.hawkular import CanonicalPath, Resource, ResourceData, ResourceType
 
+random.seed(17)
+
 
 def fake_urlopen(c_client, url, headers, params):
     """

--- a/tests/test_hawkular.py
+++ b/tests/test_hawkular.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from random import sample
+from random import sample, seed
 from unittest.mock import patch
 from urllib.parse import urlparse
 
@@ -11,7 +11,8 @@ import pytest
 from wrapanapi.systems import HawkularSystem
 from wrapanapi.systems.hawkular import CanonicalPath, Resource, ResourceData, ResourceType
 
-random.seed(17)
+
+seed(17)
 
 
 def fake_urlopen(c_client, url, headers, params):

--- a/tests/test_hawkular.py
+++ b/tests/test_hawkular.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from random import sample, seed
+from random import Random
 from unittest.mock import patch
 from urllib.parse import urlparse
 
@@ -10,8 +10,6 @@ import pytest
 
 from wrapanapi.systems import HawkularSystem
 from wrapanapi.systems.hawkular import CanonicalPath, Resource, ResourceData, ResourceType
-
-seed(17)
 
 
 def fake_urlopen(c_client, url, headers, params):
@@ -104,7 +102,7 @@ def datasource(provider):
     datasources = provider.inventory.list_server_datasource()
     assert len(datasources) > 0, "No resource data is listed for any of datasources"
     new_datasource = None
-    for datasource in sample(datasources, 1):
+    for datasource in Random(17).sample(datasources, 1):
         r_data = _read_resource_data(provider, datasource)
         assert r_data
 


### PR DESCRIPTION
## Description

This PR sets a fixed global random seed after imports in the test file to ensure deterministic and reproducible test behavior.

## Motivation

Some tests rely on randomness without a fixed seed, which can lead to flaky tests, inconsistent CI results, and difficulty reproducing failures.

## Change

A global random seed is initialized to make random behavior consistent across test runs.

## Benefits

- More reproducible and reliable tests  
- Easier debugging of failures  
- Consistent CI behavior  

The issue was identified during an ongoing research project.