### PR TITLE
Defer import of system modules and Azure SDKs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.2
+    rev: v0.15.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -24,7 +24,7 @@ repos:
       - id: end-of-file-fixer
       - id: debug-statements
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py3-plus, --py311-plus]

--- a/wrapanapi/__init__.py
+++ b/wrapanapi/__init__.py
@@ -1,20 +1,5 @@
 # Imports for convenience
 from .entities.vm import VmState
-from .systems.container.podman import Podman
-from .systems.container.rhopenshift import Openshift
-from .systems.ec2 import EC2System
-from .systems.google import GoogleCloudSystem
-from .systems.hawkular import HawkularSystem
-from .systems.lenovo import LenovoSystem
-from .systems.msazure import AzureSystem
-from .systems.nuage import NuageSystem
-from .systems.openstack import OpenstackSystem
-from .systems.openstack_infra import OpenstackInfraSystem
-from .systems.redfish import RedfishSystem
-from .systems.rhevm import RHEVMSystem
-from .systems.scvmm import SCVMMSystem
-from .systems.vcloud import VmwareCloudSystem
-from .systems.virtualcenter import VMWareSystem
 
 __all__ = [
     "EC2System",
@@ -34,3 +19,68 @@ __all__ = [
     "Podman",
     "VmState",
 ]
+
+
+def __getattr__(name):
+    """Lazy import system classes to avoid loading dependencies for unused providers."""
+    if name == "EC2System":
+        from .systems.ec2 import EC2System
+
+        return EC2System
+    elif name == "GoogleCloudSystem":
+        from .systems.google import GoogleCloudSystem
+
+        return GoogleCloudSystem
+    elif name == "HawkularSystem":
+        from .systems.hawkular import HawkularSystem
+
+        return HawkularSystem
+    elif name == "LenovoSystem":
+        from .systems.lenovo import LenovoSystem
+
+        return LenovoSystem
+    elif name == "AzureSystem":
+        from .systems.msazure import AzureSystem
+
+        return AzureSystem
+    elif name == "NuageSystem":
+        from .systems.nuage import NuageSystem
+
+        return NuageSystem
+    elif name == "OpenstackSystem":
+        from .systems.openstack import OpenstackSystem
+
+        return OpenstackSystem
+    elif name == "OpenstackInfraSystem":
+        from .systems.openstack_infra import OpenstackInfraSystem
+
+        return OpenstackInfraSystem
+    elif name == "RedfishSystem":
+        from .systems.redfish import RedfishSystem
+
+        return RedfishSystem
+    elif name == "RHEVMSystem":
+        from .systems.rhevm import RHEVMSystem
+
+        return RHEVMSystem
+    elif name == "SCVMMSystem":
+        from .systems.scvmm import SCVMMSystem
+
+        return SCVMMSystem
+    elif name == "VmwareCloudSystem":
+        from .systems.vcloud import VmwareCloudSystem
+
+        return VmwareCloudSystem
+    elif name == "VMWareSystem":
+        from .systems.virtualcenter import VMWareSystem
+
+        return VMWareSystem
+    elif name == "Openshift":
+        from .systems.container.rhopenshift import Openshift
+
+        return Openshift
+    elif name == "Podman":
+        from .systems.container.podman import Podman
+
+        return Podman
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/wrapanapi/systems/__init__.py
+++ b/wrapanapi/systems/__init__.py
@@ -1,17 +1,3 @@
-from .ec2 import EC2System
-from .google import GoogleCloudSystem
-from .hawkular import HawkularSystem
-from .lenovo import LenovoSystem
-from .msazure import AzureSystem
-from .nuage import NuageSystem
-from .openstack import OpenstackSystem
-from .openstack_infra import OpenstackInfraSystem
-from .redfish import RedfishSystem
-from .rhevm import RHEVMSystem
-from .scvmm import SCVMMSystem
-from .vcloud import VmwareCloudSystem
-from .virtualcenter import VMWareSystem
-
 __all__ = [
     "EC2System",
     "GoogleCloudSystem",
@@ -27,3 +13,60 @@ __all__ = [
     "VmwareCloudSystem",
     "VMWareSystem",
 ]
+
+
+def __getattr__(name):
+    """Lazy import system classes to avoid loading dependencies for unused providers."""
+    if name == "EC2System":
+        from .ec2 import EC2System
+
+        return EC2System
+    elif name == "GoogleCloudSystem":
+        from .google import GoogleCloudSystem
+
+        return GoogleCloudSystem
+    elif name == "HawkularSystem":
+        from .hawkular import HawkularSystem
+
+        return HawkularSystem
+    elif name == "LenovoSystem":
+        from .lenovo import LenovoSystem
+
+        return LenovoSystem
+    elif name == "AzureSystem":
+        from .msazure import AzureSystem
+
+        return AzureSystem
+    elif name == "NuageSystem":
+        from .nuage import NuageSystem
+
+        return NuageSystem
+    elif name == "OpenstackSystem":
+        from .openstack import OpenstackSystem
+
+        return OpenstackSystem
+    elif name == "OpenstackInfraSystem":
+        from .openstack_infra import OpenstackInfraSystem
+
+        return OpenstackInfraSystem
+    elif name == "RedfishSystem":
+        from .redfish import RedfishSystem
+
+        return RedfishSystem
+    elif name == "RHEVMSystem":
+        from .rhevm import RHEVMSystem
+
+        return RHEVMSystem
+    elif name == "SCVMMSystem":
+        from .scvmm import SCVMMSystem
+
+        return SCVMMSystem
+    elif name == "VmwareCloudSystem":
+        from .vcloud import VmwareCloudSystem
+
+        return VmwareCloudSystem
+    elif name == "VMWareSystem":
+        from .virtualcenter import VMWareSystem
+
+        return VMWareSystem
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/wrapanapi/systems/nuage.py
+++ b/wrapanapi/systems/nuage.py
@@ -22,10 +22,10 @@ class NuageSystem(System):
         # entities.count() == (fetcher, served object, count of fetched objects)
         "num_security_group": lambda self: self.api.policy_groups.count()[2],
         # Filter out 'BackHaulSubnet' and combine it with l2_domains the same way CloudForms does
-        "num_cloud_subnet": lambda self: self.api.subnets.count(filter="name != 'BackHaulSubnet'")[
-            2
-        ]
-        + self.api.l2_domains.count()[2],
+        "num_cloud_subnet": lambda self: (
+            self.api.subnets.count(filter="name != 'BackHaulSubnet'")[2]
+            + self.api.l2_domains.count()[2]
+        ),
         "num_cloud_tenant": lambda self: self.api.enterprises.count()[2],
         "num_network_router": lambda self: self.api.domains.count()[2],
         "num_cloud_network": lambda self: len(self.list_floating_network_resources()),


### PR DESCRIPTION
Fixes:
- Resolve an issue where importing `VmState` in Robottelo could trigger errors due to the eager loading of all system provider modules and their heavy dependencies. This change allows `VmState` to be imported without pulling in unused provider SDKs.

Refactoring:
- Implement `__getattr__` in `wrapanapi/__init__.py` and `wrapanapi/systems/__init__.py` to lazily import system classes (e.g., `EC2System`, `VMWareSystem`). This defers the loading of module dependencies until a specific system class is accessed.
- Introduce lazy importing for Azure SDK components within `wrapanapi/systems/msazure.py`. Azure dependencies are now loaded only when an Azure system or entity is instantiated, avoiding unnecessary module loading and potential import errors when the SDK is not present or needed.
- Adjust a multi-line expression in `wrapanapi/systems/nuage.py` for improved readability.

Configuration:
- Update `ruff-pre-commit` to version `v0.15.0`.
- Update `pyupgrade` to version `v3.21.2`.